### PR TITLE
feat: only load Instagram script when needed

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,11 +1,13 @@
 exports.onRouteUpdate = () => {
-  // Wait to ensure page is rendered first.
-  setTimeout(() => {
-    if (
-      typeof gatsbyLoadInstagram !== `undefined` &&
-      typeof window.gatsbyLoadInstagram === `function`
-    ) {
-      window.gatsbyLoadInstagram();
-    }
-  }, 0);
+  if (document.querySelector('.instagram-media') !== null) {
+    // Wait to ensure page is rendered first.
+    setTimeout(() => {
+      if (
+        typeof gatsbyLoadInstagram !== `undefined` &&
+        typeof window.gatsbyLoadInstagram === `function`
+      ) {
+        window.gatsbyLoadInstagram();
+      }
+    }, 0);
+  }
 };


### PR DESCRIPTION
Just like `gatsby-plugin-twitter` does.

https://github.com/gatsbyjs/gatsby/blob/a9704e905746f2369af19b71ad6014fef6119233/packages/gatsby-plugin-twitter/src/gatsby-browser.js#L40-L53