### PR TITLE
chore: update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 node_modules
 coverage
 dist
-.opt-in
-.opt-out
 .DS_Store
 
 # these cause more harm than good

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hooks: {
+    'pre-commit': 'kcd-scripts pre-commit',
+  },
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
-sudo: false
 language: node_js
 cache: npm
 notifications:
   email: false
 node_js:
-  - '8'
-  - '10'
-  - '12'
+  - 10.13
+  - 12
+  - node
 install: npm install
-script: npm run validate
-after_success: kcd-scripts travis-after-success
+script:
+  - npm run validate
+  - npx codecov@3
 branches:
-  only: master
+  only:
+    - master
+    - beta
+
+jobs:
+  include:
+    - stage: release
+      node_js: 12
+      script: kcd-scripts travis-release

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "all-contributors-cli": "^6.11.2",
-    "babel-preset-gatsby-package": "^0.2.14",
-    "kcd-scripts": "^1.12.1",
-    "react": "^16.12.0"
+    "all-contributors-cli": "^6.14.0",
+    "babel-preset-gatsby-package": "^0.3.0",
+    "kcd-scripts": "^5.4.0",
+    "react": "^16.13.1"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.20.0"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=10.13.0",
     "npm": ">=6",
     "yarn": ">=1"
   }


### PR DESCRIPTION
BREAKING CHANGE: `node@>=10.13.0` is required
BREAKING CHANGE: `gatsby@^2.20.0` is required

https://gatsbyjs.org/blog/2020-03-20-dropping-support-for-node-8